### PR TITLE
fix: launch config to point to right executable

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,17 +5,10 @@
 			"request": "launch",
 			"name": "Launch Endpoint",
 			"type": "node",
-			"program": "https://cdn.unyt.org/uix/run.ts",
 			"cwd": "${workspaceFolder}",
-			"runtimeExecutable": "/deno/latest/bin/deno",
-			"runtimeArgs": [
-				"run",
-				"--no-check", "--importmap", "importmap.dev.json",
-				"--allow-all"
-			],
+			"runtimeExecutable": "/home/vscode/.deno/bin/uix",
 			"attachSimplePort": 9229,
 			"args": [
-				"--watch"
 			],
 			"console": "integratedTerminal"
 		}


### PR DESCRIPTION
Rewrote the launch configuration to start the endpoint with default arguments. This helps people getting started, without reading any docs.